### PR TITLE
Do not use be_sessions.ses_name on TYPO3 v8

### DIFF
--- a/Classes/Controller/Pi1.php
+++ b/Classes/Controller/Pi1.php
@@ -155,7 +155,6 @@ class Pi1 extends AbstractUserAuthentication {
 					// The be-session gets the same id and hashlock as the current fe-session. Don't know if this is usefull but..
 				$insertFields = array(
 						'ses_id' => $GLOBALS['TSFE']->fe_user->user['ses_id'],
-						'ses_name' => $be_user_obj->name,
 						'ses_iplock' => $this->beuser['disableIPlock'] ?
 							'[DISABLED]' : $be_user_obj->ipLockClause_remoteIPNumber($be_user_obj->lockIP),
 						'ses_userid' => $this->beuser[$be_user_obj->userid_column],
@@ -164,6 +163,7 @@ class Pi1 extends AbstractUserAuthentication {
 
                 if (version_compare(TYPO3_branch, '8', '<')) {
                     $insertFields['ses_hashlock'] = $GLOBALS['TSFE']->fe_user->user['ses_hashlock'];
+                    $insertFields['ses_name']     = $be_user_obj->name;
                 }
 
 					// CAB - check if there already is an entry first


### PR DESCRIPTION
This field has been removed and does not exist in v8 anymore:
- https://forge.typo3.org/issues/79720
- https://review.typo3.org/51821
- https://github.com/TYPO3/typo3/commit/c3c7c401a342d3436845d197ce1848688e4f96c2

simulatebe 3.0.4 on typo3 v8 does not work currently.
I know it's a bit late, but maybe you can do a bugfix release 3.0.5.

:warning: This patch is against tag 3.0.4, not against master.